### PR TITLE
fix: add missing response body close

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -244,6 +244,7 @@ func (p *Plugin) fetchPublicKeys(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get discovery: %w", err)
 	}
+	defer response.Body.Close()
 
 	var cfg discoveryConfig
 	if err = json.NewDecoder(response.Body).Decode(&cfg); err != nil {
@@ -267,6 +268,7 @@ func (p *Plugin) fetchPublicKeys(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get jwks: %w", err)
 	}
+	defer response.Body.Close()
 
 	var jwksKeys jsonWebKeySet
 	if err = json.NewDecoder(response.Body).Decode(&jwksKeys); err != nil {


### PR DESCRIPTION
We noticed some weird memory usages with traefik, it could be because we missed the response close when doing http calls.